### PR TITLE
fix dep versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ setup(
         "web3>=6",
         "eth-typing",
         "eth-abi",
+        "eth-account<=0.8.0",
+        "setuptools>=68.0.0",
         # django-bootstrap3 22.2 under py3.8, added for pip legacy resolver to avoid conflicts
         'importlib-metadata<3; python_version<"3.8"',
     ],


### PR DESCRIPTION
Using Python 3.12.8

Mostly followed the event setup instructions. Here's the revised version with my configs

## Event Setup Instructions
1. Under the event, go to Settings -> Plugins -> Payment Providers -> click on Enable under "Pretix Ethereum Payment Provider"
2. Next, under Settings, go to Payment -> "ETH or DAI" -> Settings -> click on "enable payment method".
3. Next, scroll down and set the values for the following:
"TOKEN_RATE" - This is a JSON e.g.
```
"{\"ETH_RATE\": 4000, \"DAI_RATE\": 1}"
```
i.e. KEY = <CRYPTO_SMBOL>_RATE and VALUE = value of 1 unit in your fiat currency e.g. USD, EUR etc. For USD, above example says 1 ETH = 4000$. If EUR was chosen, then this says 1 ETH = 4000EUR.

Note that the Ethereum rate will automatically reflect the current market price (regardless of which ETH_RATE you put in the config) - the ETH_RATE you define here is a fallback in the unlikely scenario that the plugin price feeds are down. The ETH_RATE will ONLY automatically reflect the current market price when Event Currency is set to either USD or EUR. If you set your event currency to ANYTHING ELSE the ETH rate will not automatically reflect its market price - it must then be manually input & updated regularly.

4. Select the networks you want under the "Networks" option. I set Optimism Mainnet and Arbitrum Mainnet. I set "RPC URLs for networks" to this:

```
"{\"Optimism_RPC_URL\": \"https://opt-mainnet.g.alchemy.com/v2/_2A5g_7BNLEHf3tukpYJG-8J9N9mPXIe\",\"Arbitrum_RPC_URL\": \"https://arb-mainnet.g.alchemy.com/v2/_2A5g_7BNLEHf3tukpYJG-8J9N9mPXIe\"}"
```

i.e. KEY = <Network ID>_RPC_URL and VALUE = RPC URL. Network IDs can be found [in tokens.py](https://github.com/daimo-eth/pretix-eth-payment-plugin/blob/master/pretix_eth/network/tokens.py)

5. "Payment receiver address" - Ethereum address at which all payments will be sent to

6. "WalletConnect project ID" - I used the one we're using in pay-web: `ea6c5b36001c18b96e06128f14c06f40`

You can now play with the event by clicking on the "Go to Shop" button at the top left (next to the event name)